### PR TITLE
Support context in establishing a connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Motivation
 There are many MySQL drivers that implement the [database/sql](https://golang.org/pkg/database/sql/) interface.
-However, using this generic interface, especialy in the [`Scan`](https://golang.org/pkg/database/sql/#Row.Scan) method, requires the storage of many objects in the heap. 
+However, using this generic interface, especially in the [`Scan`](https://golang.org/pkg/database/sql/#Row.Scan) method, requires the storage of many objects in the heap.
 
 Reading a massive number of records from a DB can significantly increase the Garbage Collection (GC) pause-time that can be very sensitive for high-throughput, low-latency applications. 
 
@@ -33,7 +33,7 @@ go-sql-driver: records read 10000  HEAP 30010  time 3.377241ms
 ```
 
 ## Goal
-The main goals of this library are: *performance* over flexibility, *simplicity* over complexity. Any new feature shouldn't decrease the performance of the exising code base. 
+The main goals of this library are: *performance* over flexibility, *simplicity* over complexity. Any new feature shouldn't decrease the performance of the existing code base.
 
 Any improvements to productivity are always welcome. There is no plan to convert this library into an ORM. The plan is to keep it simple and, still keep supporting all of the MySQL features.
 

--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,7 @@
 package mysqldriver
 
 import (
+	"context"
 	"net"
 
 	"github.com/pubnative/mysqlproto-go"
@@ -28,10 +29,19 @@ type Stats struct {
 	Syscalls int // number of system calls performed to read all packets
 }
 
-// NewConn establishes connection to the DB. After obtaining the connection,
+// NewConn establishes a connection to the DB. After obtaining the connection,
 // it sends "SET NAMES utf8" command to the DB
 func NewConn(username, password, protocol, address, database string) (*Conn, error) {
-	conn, err := net.Dial(protocol, address)
+	return NewConnContext(context.Background(), username, password, protocol, address, database)
+}
+
+// NewConnContext establishes a connection to the DB. After obtaining the connection,
+// it sends "SET NAMES utf8" command to the DB
+//
+// Go Context is only used to establish a TCP connection.
+// TODO use Go Context to establish a MySQL connection.
+func NewConnContext(ctx context.Context, username, password, protocol, address, database string) (*Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, protocol, address)
 	if err != nil {
 		return nil, err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,9 +1,10 @@
 package mysqldriver
 
 import (
-	"github.com/pubnative/mysqlproto-go"
+	"context"
 	"testing"
 
+	"github.com/pubnative/mysqlproto-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,6 +23,20 @@ func TestNewConnError(t *testing.T) {
 	assert.Equal(t, errPkt.SQLState, "42000")
 	assert.Equal(t, errPkt.ErrorMessage, "Unknown database 'unknown'")
 	assert.False(t, conn.valid)
+}
+
+func TestNewConnContextSuccess(t *testing.T) {
+	conn, err := NewConnContext(context.Background(), "root", "", "tcp", "127.0.0.1:3306", "test")
+	assert.NoError(t, err)
+	assert.True(t, conn.valid)
+}
+
+func TestNewConnContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewConnContext(ctx, "root", "", "tcp", "127.0.0.1:3306", "test")
+	assert.EqualError(t, err, "dial tcp 127.0.0.1:3306: operation was canceled")
 }
 
 func TestConnClose(t *testing.T) {


### PR DESCRIPTION
This PR doesn't fully support Go Context for creating a connection
but at least lets the user to set a timeout for TCP handshake.