### PR TITLE
Make it possible to time out TCP reads

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3,6 +3,7 @@ package mysqldriver
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/pubnative/mysqlproto-go"
 )
@@ -31,8 +32,8 @@ type Stats struct {
 
 // NewConn establishes a connection to the DB. After obtaining the connection,
 // it sends "SET NAMES utf8" command to the DB
-func NewConn(username, password, protocol, address, database string) (*Conn, error) {
-	return NewConnContext(context.Background(), username, password, protocol, address, database)
+func NewConn(username, password, protocol, address, database string, readTimeout time.Duration) (*Conn, error) {
+	return NewConnContext(context.Background(), username, password, protocol, address, database, readTimeout)
 }
 
 // NewConnContext establishes a connection to the DB. After obtaining the connection,
@@ -40,7 +41,7 @@ func NewConn(username, password, protocol, address, database string) (*Conn, err
 //
 // Go Context is only used to establish a TCP connection.
 // TODO use Go Context to establish a MySQL connection.
-func NewConnContext(ctx context.Context, username, password, protocol, address, database string) (*Conn, error) {
+func NewConnContext(ctx context.Context, username, password, protocol, address, database string, readTimeout time.Duration) (*Conn, error) {
 	conn, err := (&net.Dialer{}).DialContext(ctx, protocol, address)
 	if err != nil {
 		return nil, err
@@ -48,7 +49,7 @@ func NewConnContext(ctx context.Context, username, password, protocol, address, 
 
 	stream, err := mysqlproto.ConnectPlainHandshake(
 		conn, capabilityFlags,
-		username, password, database, nil,
+		username, password, database, nil, readTimeout,
 	)
 
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,9 @@ func NewConn(username, password, protocol, address, database string, readTimeout
 //
 // Go Context is only used to establish a TCP connection.
 // TODO use Go Context to establish a MySQL connection.
-func NewConnContext(ctx context.Context, username, password, protocol, address, database string, readTimeout time.Duration) (*Conn, error) {
+func NewConnContext(ctx context.Context, username, password, protocol, address,
+	database string, readTimeout time.Duration) (*Conn, error) {
+
 	conn, err := (&net.Dialer{}).DialContext(ctx, protocol, address)
 	if err != nil {
 		return nil, err

--- a/conn_test.go
+++ b/conn_test.go
@@ -3,19 +3,20 @@ package mysqldriver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pubnative/mysqlproto-go"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewConnSuccess(t *testing.T) {
-	conn, err := NewConn("root", "", "tcp", "127.0.0.1:3306", "test")
+	conn, err := NewConn("root", "", "tcp", "127.0.0.1:3306", "test", time.Duration(0))
 	assert.Nil(t, err)
 	assert.True(t, conn.valid)
 }
 
 func TestNewConnError(t *testing.T) {
-	conn, err := NewConn("root", "", "tcp", "127.0.0.1:3306", "unknown")
+	conn, err := NewConn("root", "", "tcp", "127.0.0.1:3306", "unknown", time.Duration(0))
 	assert.NotNil(t, err)
 	errPkt, ok := err.(mysqlproto.ERRPacket)
 	assert.True(t, ok)
@@ -26,7 +27,7 @@ func TestNewConnError(t *testing.T) {
 }
 
 func TestNewConnContextSuccess(t *testing.T) {
-	conn, err := NewConnContext(context.Background(), "root", "", "tcp", "127.0.0.1:3306", "test")
+	conn, err := NewConnContext(context.Background(), "root", "", "tcp", "127.0.0.1:3306", "test", time.Duration(0))
 	assert.NoError(t, err)
 	assert.True(t, conn.valid)
 }
@@ -35,12 +36,12 @@ func TestNewConnContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := NewConnContext(ctx, "root", "", "tcp", "127.0.0.1:3306", "test")
+	_, err := NewConnContext(ctx, "root", "", "tcp", "127.0.0.1:3306", "test", time.Duration(0))
 	assert.EqualError(t, err, "dial tcp 127.0.0.1:3306: operation was canceled")
 }
 
 func TestConnClose(t *testing.T) {
-	conn, err := NewConn("root", "", "tcp", "127.0.0.1:3306", "test")
+	conn, err := NewConn("root", "", "tcp", "127.0.0.1:3306", "test", time.Duration(0))
 	assert.Nil(t, err)
 	assert.Nil(t, conn.Close())
 	assert.True(t, conn.closed)

--- a/db.go
+++ b/db.go
@@ -3,6 +3,7 @@ package mysqldriver
 import (
 	"errors"
 	"strings"
+	"time"
 )
 
 var ErrClosedDB = errors.New("mysqldriver: can't get connection from the closed DB")
@@ -17,6 +18,7 @@ type DB struct {
 	protocol string
 	address  string
 	database string
+	readTimeout time.Duration
 }
 
 // NewDB initializes pool of connections but doesn't
@@ -25,7 +27,7 @@ type DB struct {
 // Pool size is fixed and can't be resized later.
 // DataSource parameter has the following format:
 // [username[:password]@][protocol[(address)]]/dbname
-func NewDB(dataSource string, pool int) *DB {
+func NewDB(dataSource string, pool int, readTimeout time.Duration) *DB {
 	usr, pass, proto, addr, dbname := parseDataSource(dataSource)
 	conns := make(chan *Conn, pool)
 	return &DB{
@@ -106,7 +108,7 @@ func (db *DB) Close() []error {
 }
 
 func (db *DB) dial() (*Conn, error) {
-	conn, err := NewConn(db.username, db.password, db.protocol, db.address, db.database)
+	conn, err := NewConn(db.username, db.password, db.protocol, db.address, db.database, db.readTimeout)
 	if err != nil {
 		return conn, err
 	}

--- a/query.go
+++ b/query.go
@@ -1,6 +1,7 @@
 package mysqldriver
 
 import (
+	"net"
 	"strconv"
 
 	"github.com/pubnative/mysqlproto-go"
@@ -373,6 +374,9 @@ func (c *Conn) Query(sql string) (*Rows, error) {
 	resultSet, err := mysqlproto.ComQueryResponse(c.conn)
 	if err != nil {
 		if _, ok := err.(mysqlproto.ERRPacket); !ok {
+			c.valid = false
+		}
+		if err, ok := err.(net.Error); ok && err.Timeout() {
 			c.valid = false
 		}
 		return nil, err

--- a/query.go
+++ b/query.go
@@ -376,9 +376,6 @@ func (c *Conn) Query(sql string) (*Rows, error) {
 		if _, ok := err.(mysqlproto.ERRPacket); !ok {
 			c.valid = false
 		}
-		if err, ok := err.(net.Error); ok && err.Timeout() {
-			c.valid = false
-		}
 		return nil, err
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -3,6 +3,7 @@ package mysqldriver
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/pubnative/mysqlproto-go"
 	"github.com/stretchr/testify/assert"
@@ -301,7 +302,7 @@ func TestQueryRowReader(t *testing.T) {
 }
 
 func TestQueryMarkConnInvalidWhenStreamIsBroken(t *testing.T) {
-	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10)
+	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10, time.Duration(0))
 	conn, err := db.GetConn()
 	assert.Nil(t, err)
 
@@ -424,7 +425,7 @@ func TestExecUpdateNotFound(t *testing.T) {
 }
 
 func TestExecMarkConnInvalidWhenStreamIsBroken(t *testing.T) {
-	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10)
+	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10, time.Duration(0))
 	conn, err := db.GetConn()
 	assert.Nil(t, err)
 
@@ -435,7 +436,7 @@ func TestExecMarkConnInvalidWhenStreamIsBroken(t *testing.T) {
 }
 
 func setup(t *testing.T, fn func(conn *Conn)) {
-	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10)
+	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10, time.Duration(0))
 	conn, err := db.GetConn()
 	assert.Nil(t, err)
 
@@ -473,7 +474,7 @@ func setup(t *testing.T, fn func(conn *Conn)) {
 }
 
 func ExampleConn_Query_default() {
-	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10)
+	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10, time.Duration(0))
 	conn, err := db.GetConn()
 	if err != nil {
 		// handle error
@@ -504,7 +505,7 @@ func ExampleConn_Query_default() {
 }
 
 func ExampleConn_Query_null() {
-	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10)
+	db := NewDB("root@tcp(127.0.0.1:3306)/test", 10, time.Duration(0))
 	conn, err := db.GetConn()
 	if err != nil {
 		// handle error


### PR DESCRIPTION
This is just plumbing changes to enable the changes in https://github.com/pubnative/mysqlproto-go/pull/2. The same questions apply re: backwards compatibility.