### PR TITLE
Avoid string allocations in `NullBool` and `NullInt` methods

### DIFF
--- a/query.go
+++ b/query.go
@@ -139,12 +139,12 @@ func (r *Rows) Int() int {
 // NullInt method uses strconv.Atoi to convert string into int.
 // (see https://golang.org/pkg/strconv/#Atoi)
 func (r *Rows) NullInt() (int, bool) {
-	str, null := r.NullString()
+	str, null := r.NullBytes()
 	if null {
 		return 0, true
 	}
 
-	num, err := strconv.Atoi(str)
+	num, err := atoi(str)
 	if err != nil {
 		r.errParse = err
 	}
@@ -328,12 +328,12 @@ func (r *Rows) Bool() bool {
 // NullBool method uses strconv.ParseBool to convert string into bool.
 // (see https://golang.org/pkg/strconv/#ParseBool)
 func (r *Rows) NullBool() (bool, bool) {
-	str, null := r.NullString()
+	str, null := r.NullBytes()
 	if null {
 		return false, true
 	}
 
-	b, err := strconv.ParseBool(str)
+	b, err := parseBool(str)
 	if err != nil {
 		r.errParse = err
 	}

--- a/row.go
+++ b/row.go
@@ -92,12 +92,12 @@ func (r Row) String(col string) string {
 // NullInt method uses strconv.Atoi to convert string into int.
 // (see https://golang.org/pkg/strconv/#Atoi)
 func (r Row) NullInt(col string) (int, bool) {
-	value, null := r.NullString(col)
+	value, null := r.NullBytes(col)
 	if null {
 		return 0, true
 	}
 
-	num, err := strconv.Atoi(value)
+	num, err := atoi(value)
 	if err != nil {
 		r.rows.errParse = err
 	}
@@ -281,12 +281,12 @@ func (r Row) Float64(col string) float64 {
 // NullBool method uses strconv.ParseBool to convert string into bool.
 // (see https://golang.org/pkg/strconv/#ParseBool)
 func (r Row) NullBool(col string) (bool, bool) {
-	str, null := r.NullString(col)
+	str, null := r.NullBytes(col)
 	if null {
 		return false, true
 	}
 
-	b, err := strconv.ParseBool(str)
+	b, err := parseBool(str)
 	if err != nil {
 		r.rows.errParse = err
 	}

--- a/strconvutils.go
+++ b/strconvutils.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Taken from https://github.com/golang/go/blob/master/src/strconv/atoi.go
+// and adapted to parse from []byte instead of string.
+
+package mysqldriver
+import (
+	"strconv"
+)
+
+func atoi(s []byte) (int, error) {
+	const fnAtoi = "Atoi"
+
+	sLen := len(s)
+	if strconv.IntSize == 32 && (0 < sLen && sLen < 10) ||
+		strconv.IntSize == 64 && (0 < sLen && sLen < 19) {
+		// Fast path for small integers that fit int type.
+		s0 := s
+		if s[0] == '-' || s[0] == '+' {
+			s = s[1:]
+			if len(s) < 1 {
+				return 0, &strconv.NumError{fnAtoi, string(s0), strconv.ErrSyntax}
+			}
+		}
+
+		n := 0
+		for _, ch := range s {
+			ch -= '0'
+			if ch > 9 {
+				return 0, &strconv.NumError{fnAtoi, string(s0), strconv.ErrSyntax}
+			}
+			n = n*10 + int(ch)
+		}
+		if s0[0] == '-' {
+			n = -n
+		}
+		return n, nil
+	}
+
+	// Slow path for invalid, big, or underscored integers.
+	i64, err := strconv.ParseInt(string(s), 10, 0)
+	if nerr, ok := err.(*strconv.NumError); ok {
+		nerr.Func = fnAtoi
+	}
+	return int(i64), err
+}
+
+func parseBool(str []byte) (bool, error) {
+	switch string(str) { // TODO check that this is actually optimised away
+	case "1", "t", "T", "true", "TRUE", "True":
+		return true, nil
+	case "0", "f", "F", "false", "FALSE", "False":
+		return false, nil
+	}
+	return false, syntaxError("ParseBool", string(str))
+}
+
+func syntaxError(fn, str string) *strconv.NumError {
+	return &strconv.NumError{fn, str, strconv.ErrSyntax}
+}

--- a/strconvutils.go
+++ b/strconvutils.go
@@ -74,7 +74,7 @@ func atoi(s []byte) (int, error) {
 }
 
 func parseBool(str []byte) (bool, error) {
-	switch string(str) { // TODO check that this is actually optimised away
+	switch string(str) {
 	case "1", "t", "T", "true", "TRUE", "True":
 		return true, nil
 	case "0", "f", "F", "false", "FALSE", "False":


### PR DESCRIPTION
Right now `NullInt` and `NullBool` get a byte slice from the underlying DB connection buffer, convert it to a string and then parse that string into an int/bool. The conversion from `[]byte` to `string` requires a memory allocation, which we can avoid by parsing the int/bool directly from the `[]byte`. `atoi` and `parseBool` are copied from Go's standard library and modified to work on byte slices instead of strings while preserving the existing behaviour (including errors etc.). Both methods are pretty simple and neither one has had any meaningful changes in the last few years, so I think the maintenance burden of copying them into our code base is pretty small.